### PR TITLE
Add functionality to close the logger

### DIFF
--- a/include/mirror/logger.hpp
+++ b/include/mirror/logger.hpp
@@ -93,17 +93,19 @@ namespace mirror {
          */
         void configure(uint16_t port, const std::string &componentName, const std::string &address = "localhost");
 
+        inline void close() { Logger::getInstance()->~Logger(); }
+
     protected: // Functions
         /**
-         * Default constructor. Registers a function to be called upon program exit that calls the Logger destructor
+         * Default constructor.
          */
-        inline Logger() : m_Configured(false) { std::atexit([]() { Logger::getInstance()->~Logger(); }); }
+        inline Logger() : m_Configured(false) {}
 
         // Destructor
         /**
-         * Destructor for the Logger class. Destroys the socket when called.
+         * Destructor for the Logger class. Destroys the socket and context when called.
          */
-        inline ~Logger() { m_LogServerSocket.close(); }
+        inline ~Logger() { m_LogServerSocket.close(); socketContext.shutdown(); }
 
     private: // Functions
         /**

--- a/include/mirror/logger.hpp
+++ b/include/mirror/logger.hpp
@@ -92,7 +92,10 @@ namespace mirror {
          * @param address IP address of the machine that the log server is running on
          */
         void configure(uint16_t port, const std::string &componentName, const std::string &address = "localhost");
-
+        
+        /**
+         * Shuts down the socket and destroys the Logger.
+         */
         inline void close() { Logger::getInstance()->~Logger(); }
 
     protected: // Functions

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -77,7 +77,7 @@ namespace mirror {
         std::string routingID = m_LogServerSocket.get(zmq::sockopt::routing_id);
         m_LogServerSocket.send(zmq::message_t(routingID), zmq::send_flags::sndmore);
 
-        zmq::message_t message{"@" + m_ComponentName + lineToSend + "\r\n"};
+        zmq::message_t message{"@" + m_ComponentName + lineToSend + "\n"};
         m_LogServerSocket.send(message, zmq::send_flags::none);
     }
 


### PR DESCRIPTION
SIGINT handler cannot trigger std::atexit hook (main() has not yet returned), needed to add a function to clean up socket and destroy context so programs (specifically Dispatch) with graceful shutdown on SIGINT can exit properly.